### PR TITLE
v0.19.0: audit highs #3/#5/#6/#9 — settle ATA bind, lock/conclusion finality, mint idempotency

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,51 @@
 
 All notable changes to TurfVault are documented here. Format based on [Keep a Changelog](https://keepachangelog.com/).
 
+## [0.19.0] - 2026-05-31
+
+Security hardening from the 2026-05-31 adversarial audit (highs #3 / #5 / #6 / #9).
+No account-layout/byte-size change — Contest, EntryTokenAccount, VaultState bodies
+are untouched, so existing PDAs need no re-init. The IDL DOES change (new errors +
+`mint_entry_token` args + `set_contest_lock_time`/`set_contest_conclusion_time`
+optional cosigner), so turf-monster must re-pin `EXPECTED_IDL_HASH` from the
+freshly-built IDL.
+
+### Security
+
+- **#3 `settle_contest` — bind payout destination.** Each winner's payout must
+  now land in `get_associated_token_address(settlement.wallet, payout_mint)`,
+  validated for every settlement row before the SPL transfer. Previously the
+  destination ATA was unconstrained, so a settle authority could redirect the
+  prize pool to any same-mint account while stats credited the real winner.
+  New error 6036 `InvalidPayoutDestination`.
+- **#6 `settle_contest` — entries-closed gate.** Settle now requires the derived
+  lock OR conclusion timestamp to have passed (reuses 6028 `ContestNotLocked`),
+  so a contest can't be graded while still open for entries.
+- **#5 `set_contest_lock_time` / `set_contest_conclusion_time` — finality + multisig.**
+  Pre-lock changes stay 1-of-3; amending a lock that has ALREADY PASSED requires
+  2-of-3 (optional `cosigner` + `validate_multisig`), closing the results-known
+  late-entry re-open vector. A set conclusion is likewise 2-of-3 to amend (first
+  set stays 1-of-3). Timestamps must be non-negative, a set conclusion must be in
+  the future, and a set lock must precede a set conclusion. New error 6037
+  `InvalidTimestamp`.
+- **#9 `mint_entry_token` — on-chain idempotency.** The EntryTokenAccount PDA is
+  now seeded on `sha256(source_ref)` (passed as `source_ref_hash`, asserted
+  on-chain) instead of a caller-supplied `sequence`, so re-minting the same
+  `source_ref` collides on `init` and fails. Stays 1-of-3. `source_ref` must be
+  globally unique across wallets. New error 6038 `EntryTokenSeedMismatch`.
+  Account body unchanged; `owner` still drives getProgramAccounts discovery.
+
+### Breaking (signatures, NOT account layout)
+
+- `mint_entry_token` drops `sequence`, adds `source_ref_hash`.
+- `set_contest_lock_time` / `set_contest_conclusion_time` gain an optional `cosigner`.
+- turf-monster + solana-studio must update in the same deploy that FOLLOWS the
+  Squads upgrade. Rails coordination owed: entry-token PDA from
+  `sha256(source_ref)`; per-mint globally-unique `source_ref` (operator-mint
+  regression — a looped `operator_<unix_ts>` now collides); cosign path for
+  post-lock amends; `grade!` must ensure a lock/conclusion is set (else settle
+  reverts 6028); `error_interpreter` mappings for 6036/6037/6038.
+
 ## [0.18.0] - 2026-05-29
 
 Adds the second derived timestamp: a contest **conclusion** marker, parallel to

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -8,7 +8,7 @@ Anchor smart contract for contest escrow on Solana. Backend for Turf Monster (Ra
 - **Framework**: Anchor 0.32.1
 - **Rust**: 1.89.0 (via `rust-toolchain.toml`)
 - **Network**: Localnet (dev), Devnet (staging)
-- **Version**: 0.18.0
+- **Version**: 0.19.0
 - **Binary**: 495,280 bytes / 3.448 SOL permanent rent
 - **Upgrade authority**: Squads V4 2-of-3 multisig PDA `BW13kgfiG2koFn3WRkte21NW9TFygsD1ge2fNJdjH6kC` (OPSEC-002 — see "Deploying an upgrade" below). `anchor deploy` no longer works for upgrades; the first deploy of a fresh program ID still uses `solana program deploy` from Alex Bot, then `set-upgrade-authority` to the Squads vault.
 
@@ -88,14 +88,14 @@ pub fn validate_multisig(&self, s1: &Pubkey, s2: &Pubkey) -> bool {
 | `set_username` | User signs | Wallet owner signs; v0.15.1 on-chain validation (reserved prefixes, ASCII, ≥3 chars). |
 | `create_season` | 1-of-3 | Any signer can create. Seed schedule immutable after create. |
 | `create_contest` | 1-of-3 + creator | Admin pays SOL rent; creator (Phantom or server-keypair) signs the USDC prize-pool transfer. |
-| `set_contest_lock_time` | 1-of-3 | Sets `Contest.lock_timestamp` (derived time-lock). Rejected once `conclusion_timestamp` has passed (`ContestConcluded` 6035). |
-| `set_contest_conclusion_time` | 1-of-3 | Sets `Contest.conclusion_timestamp`; once passed, the lock time is final. |
+| `set_contest_lock_time` | 1-of-3 / **2-of-3 post-lock** | Sets `Contest.lock_timestamp`. Pre-lock: 1-of-3. Amending a lock that has ALREADY PASSED requires 2-of-3 (optional `cosigner`) — closes the #5 re-open vector. Rejected once concluded (`ContestConcluded` 6035) or on invalid timestamps (`InvalidTimestamp` 6037). |
+| `set_contest_conclusion_time` | 1-of-3 / **2-of-3 to amend** | First set (0→value): 1-of-3. Amending an already-set conclusion: 2-of-3 (optional `cosigner`). Must be in the future and after a set lock (`InvalidTimestamp` 6037). |
 | `enter_contest` | User + 1-of-3 payer | User signs SPL transfer from their ATA → currency's op-rev ATA. Admin pays SOL rent (OPSEC-024 channel discipline). |
 | `enter_contest_with_token` | User + 1-of-3 payer | Wallet must sign (OPSEC-004) to consent to token consume. |
-| `settle_contest` | **2-of-3** | SPL CPI per winner from `[b"prize_pool", contest_id]` PDA. Rails must set `set_compute_unit_limit(400_000)` — default budget tops out near ~25 winners. |
+| `settle_contest` | **2-of-3** | SPL CPI per winner from `[b"prize_pool", contest_id]` PDA → each winner's canonical ATA, bound on-chain (`InvalidPayoutDestination` 6036, #3). Requires the lock OR conclusion timestamp to have passed (`ContestNotLocked` 6028, #6). Rails must set `set_compute_unit_limit(400_000)` — default budget tops out near ~25 winners. |
 | `cancel_contest` | **2-of-3** | Status → Cancelled. Refunds full `prize_pool` to creator. Entry fees stay with operator (treated as revenue); operator-side playbook is to `mint_entry_token` goodwill credits to affected entrants. |
 | `close_contest` | 1-of-3 | Settled or Cancelled contests only. Sweeps any prize_pool dust to op-rev USDC, then closes the contest PDA (rent → admin). |
-| `mint_entry_token` | 1-of-3 | Admin mints free-entry voucher PDAs. Idempotent per `source_ref`. |
+| `mint_entry_token` | 1-of-3 | Admin mints free-entry voucher PDAs. Idempotent per `source_ref` — the PDA is seeded on `sha256(source_ref)` (passed as `source_ref_hash`, asserted on-chain, `EntryTokenSeedMismatch` 6038), so re-minting the same ref collides on init (v0.19, #9). `source_ref` must be globally unique across wallets. |
 | `register_currency` | **2-of-3** | Add a mint to `accepted_currencies` at the first empty slot. Also creates the per-currency op-rev ATA at `[b"op_rev", mint]`. |
 | `deactivate_currency` | **2-of-3** | Flips `accepted_currencies[idx].active = 0`. Slot is never reclaimed — preserves `currency_idx` stability across the program's life. |
 | `sweep_operator_revenue` | **2-of-3** | Drains a currency's op-rev ATA to `vault_state.treasury_authority` (pinned to the Squads vault PDA at init). |
@@ -118,7 +118,7 @@ pub fn validate_multisig(&self, s1: &Pubkey, s2: &Pubkey) -> bool {
 | UserAccount | `[b"user", wallet]` | One per wallet |
 | Contest | `[b"contest", contest_id]` | contest_id = SHA256 of Rails slug |
 | ContestEntry | `[b"entry", contest_id, wallet, entry_num.to_le_bytes()]` | Multiple per user |
-| EntryTokenAccount | `[b"entry_token", owner, sequence.to_le_bytes()]` | sequence = u64 LE; discover via getProgramAccounts on `owner` |
+| EntryTokenAccount | `[b"entry_token", sha256(source_ref)]` | v0.19 (#9): source_ref hashed to 32 bytes (passed as `source_ref_hash`, asserted on-chain). Discover via getProgramAccounts on `owner` (still in the body). |
 | Season | `[b"season", season_id.to_le_bytes()]` | season_id = u32 LE |
 
 ### CPI Token Transfers
@@ -218,6 +218,9 @@ All accounts use `#[derive(InitSpace)]`. Contest has `#[max_len(10)]` on `payout
 | 6033 | FeeAndPrizeBothZero | `create_contest` with `prize_pool == 0` AND all `entry_fee_by_currency` slots zero |
 | 6034 | ContestLocked | `enter_contest{,_with_token}` when `Clock.unix_timestamp >= lock_timestamp` (v0.17) |
 | 6035 | ContestConcluded | `set_contest_lock_time` rejected once `conclusion_timestamp` has passed (v0.18) |
+| 6036 | InvalidPayoutDestination | `settle_contest` winner_ata ≠ the winner's canonical ATA (v0.19, #3) |
+| 6037 | InvalidTimestamp | `set_contest_lock_time`/`set_contest_conclusion_time` given a negative/past or mis-ordered (lock ≥ conclusion) timestamp (v0.19, #5) |
+| 6038 | EntryTokenSeedMismatch | `mint_entry_token` `source_ref_hash` ≠ sha256(`source_ref`) (v0.19, #9) |
 
 ## Testing
 

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2896,10 +2896,11 @@ checksum = "5d99f8c9a7727884afe522e9bd5edbfc91a3312b36a77b5fb8926e4c31a41801"
 
 [[package]]
 name = "turf_vault"
-version = "0.18.0"
+version = "0.19.0"
 dependencies = [
  "anchor-lang",
  "anchor-spl",
+ "solana-program",
 ]
 
 [[package]]

--- a/programs/turf_vault/Cargo.toml
+++ b/programs/turf_vault/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "turf_vault"
-version = "0.18.0"
+version = "0.19.0"
 description = "Solana contest escrow with on-chain currency registry and self-custodial entries"
 edition = "2021"
 
@@ -29,6 +29,11 @@ mainnet = []
 [dependencies]
 anchor-lang = { version = "0.32.1", features = ["init-if-needed"] }
 anchor-spl = "0.32.1"
+# Direct dep for SHA-256 (solana_program::hash::hash) used to derive the
+# entry_token PDA from source_ref (v0.19, audit #9). anchor_lang::solana_program
+# is a curated facade that omits the `hash` module. Pinned to the same 2.3.x
+# already in the tree via anchor — no duplicate version.
+solana-program = "2.3"
 
 
 [lints.rust]

--- a/programs/turf_vault/src/errors.rs
+++ b/programs/turf_vault/src/errors.rs
@@ -90,4 +90,12 @@ pub enum VaultError {
     ContestLocked,                               // 6034
     #[msg("Contest has concluded — the conclusion timestamp has passed")]
     ContestConcluded,                            // 6035
+
+    // ── 6036+: new in v0.19 (audit highs #3 / #5) ─────────────────────────
+    #[msg("Settlement payout destination is not the winner's associated token account")]
+    InvalidPayoutDestination,                    // 6036
+    #[msg("Invalid contest timestamp: must be non-negative, in the future, and lock must precede conclusion")]
+    InvalidTimestamp,                            // 6037
+    #[msg("Entry token seed hash does not match sha256(source_ref)")]
+    EntryTokenSeedMismatch,                      // 6038
 }

--- a/programs/turf_vault/src/instructions/mint_entry_token.rs
+++ b/programs/turf_vault/src/instructions/mint_entry_token.rs
@@ -1,4 +1,5 @@
 use anchor_lang::prelude::*;
+use solana_program::hash::hash;
 use crate::state::{VaultState, EntryTokenAccount};
 use crate::errors::VaultError;
 
@@ -10,21 +11,30 @@ use crate::errors::VaultError;
 /// entry fee at entry time. Typical triggers: a Stripe purchase
 /// (TokenPurchaseJob), an operator gift (admin UI), a level-up reward.
 ///
-/// PDA seeds: [b"entry_token", user_wallet, sequence_le_bytes]. `sequence`
-/// is supplied by the caller (Rails picks `current_count` for the user)
-/// so multiple tokens can coexist for the same wallet without PDA
-/// collisions. Discover with `getProgramAccounts` filtered by `owner`.
+/// PDA seeds (v0.19, audit #9): [b"entry_token", source_ref_hash], where
+/// `source_ref_hash` is passed by the caller and the handler asserts it equals
+/// `sha256(source_ref)`. (The hash is passed as a fixed-size arg rather than
+/// computed in the seed expression because `anchor idl build` cannot represent
+/// a function-call seed; the on-chain assert keeps the binding sound.) The PDA
+/// is therefore derived from a hash of the external reference, so re-minting the
+/// same `source_ref` collides on `init` and fails — TRUE on-chain idempotency
+/// (replaces the old caller-supplied `sequence`, which let the same source_ref
+/// mint unlimited distinct tokens). `source_ref` must therefore be GLOBALLY
+/// unique across wallets (the Stripe path namespaces by session_id; operator
+/// mints must use a per-mint-unique ref). `owner` is stored in the account body
+/// (not a seed), so getProgramAccounts discovery by owner is unchanged.
 ///
-/// Auth: 1-of-3 vault signer (routine op). The user_wallet is NOT a
-/// signer — tokens can be minted for any wallet. (Consent at redemption
-/// time is enforced separately by the consume instructions.)
+/// Auth: 1-of-3 vault signer (routine op). The user_wallet is NOT a signer —
+/// tokens can be minted for any wallet. (Consent at redemption time is enforced
+/// separately by the consume instructions.) The seed-based idempotency closes
+/// double-mint/replay regardless of the signer count.
 ///
 /// NOT gated by vault pause — operators must be able to fulfill Stripe
 /// purchases that completed before the pause.
 ///
 /// VaultState is zero-copy (v0.16) — load()? for the signer check.
 #[derive(Accounts)]
-#[instruction(sequence: u64)]
+#[instruction(source: u8, source_ref: [u8; 64], source_ref_hash: [u8; 32])]
 pub struct MintEntryToken<'info> {
     /// Vault signer (admin) — pays SOL rent for the EntryTokenAccount PDA.
     #[account(mut)]
@@ -37,8 +47,8 @@ pub struct MintEntryToken<'info> {
     )]
     pub vault_state: AccountLoader<'info, VaultState>,
 
-    /// CHECK: The recipient wallet. Used only as a PDA seed and to set
-    /// `owner` on the new account. Not a signer; not modified.
+    /// CHECK: The recipient wallet. Used only to set `owner` on the new
+    /// account (NOT a PDA seed in v0.19). Not a signer; not modified.
     pub user_wallet: UncheckedAccount<'info>,
 
     #[account(
@@ -46,9 +56,8 @@ pub struct MintEntryToken<'info> {
         payer = admin,
         space = EntryTokenAccount::LEN,
         seeds = [
-            b"entry_token",
-            user_wallet.key().as_ref(),
-            &sequence.to_le_bytes(),
+            b"entry_token".as_ref(),
+            source_ref_hash.as_ref(),
         ],
         bump,
     )]
@@ -59,10 +68,19 @@ pub struct MintEntryToken<'info> {
 
 pub fn handle_mint_entry_token(
     ctx: Context<MintEntryToken>,
-    _sequence: u64,
     source: u8,
     source_ref: [u8; 64],
+    source_ref_hash: [u8; 32],
 ) -> Result<()> {
+    // Bind the PDA seed hash to source_ref: the seed is a caller-supplied arg
+    // (IDL-build can't encode a function-call seed), so assert it really is
+    // sha256(source_ref). Catches a wrong client-side hash loudly instead of
+    // minting at a PDA that doesn't match the stored ref (audit #9).
+    require!(
+        hash(&source_ref).to_bytes() == source_ref_hash,
+        VaultError::EntryTokenSeedMismatch
+    );
+
     let entry_token = &mut ctx.accounts.entry_token;
     entry_token.owner = ctx.accounts.user_wallet.key();
     entry_token.source = source;
@@ -73,10 +91,9 @@ pub fn handle_mint_entry_token(
     entry_token.bump = ctx.bumps.entry_token;
 
     msg!(
-        "Entry token minted for {} (source: {}, sequence: {})",
+        "Entry token minted for {} (source: {})",
         entry_token.owner,
-        source,
-        _sequence
+        source
     );
     Ok(())
 }

--- a/programs/turf_vault/src/instructions/set_contest_conclusion_time.rs
+++ b/programs/turf_vault/src/instructions/set_contest_conclusion_time.rs
@@ -6,17 +6,26 @@ use crate::errors::VaultError;
 /// timestamp (v0.18). The conclusion marks when the contest is considered done:
 /// once `Clock.unix_timestamp` passes it, `set_contest_lock_time` rejects — the
 /// lock time is final. Derived like the lock (compared against the chain Clock,
-/// no oracle). Mirrors set_contest_lock_time.
+/// no oracle).
 ///
-/// Auth: 1-of-3 vault signer. `new_conclusion_timestamp == 0` clears it
-/// ("no conclusion scheduled"). Rejected once the contest has already concluded
-/// (its current conclusion timestamp has passed) or been settled/cancelled.
+/// Auth (v0.19, audit #5):
+///   - Setting it for the FIRST time (current conclusion == 0): 1-of-3.
+///   - AMENDING an already-set conclusion (the finality marker): 2-of-3
+///     (admin + distinct `cosigner`). Clearing/postponing it at 1-of-3 would
+///     let a single key re-arm the relock — the same late-entry vector as #5.
+///   - Always rejected once the contest is settled/cancelled or has concluded.
+///
+/// Timestamps must be non-negative; a set conclusion must follow a set lock.
 ///
 /// VaultState is zero-copy (v0.16) — read via `load()?`.
 #[derive(Accounts)]
 pub struct SetContestConclusionTime<'info> {
     #[account(mut)]
     pub admin: Signer<'info>,
+
+    /// Optional second vault signer. Required (2-of-3) ONLY to amend an
+    /// already-set conclusion; omitted for the initial 1-of-3 set.
+    pub cosigner: Option<Signer<'info>>,
 
     #[account(
         seeds = [b"vault"],
@@ -37,24 +46,56 @@ pub fn handle_set_contest_conclusion_time(
     ctx: Context<SetContestConclusionTime>,
     new_conclusion_timestamp: i64,
 ) -> Result<()> {
-    let contest = &mut ctx.accounts.contest;
+    let now = Clock::get()?.unix_timestamp;
+
     require!(
-        contest.status != ContestStatus::Settled
-            && contest.status != ContestStatus::Cancelled,
+        ctx.accounts.contest.status != ContestStatus::Settled
+            && ctx.accounts.contest.status != ContestStatus::Cancelled,
         VaultError::ContestAlreadySettled
     );
-    // Once the contest has actually concluded, the conclusion is final too.
-    if contest.conclusion_timestamp != 0 {
+
+    // Once the contest has actually concluded, the conclusion is final.
+    let current_conclusion = ctx.accounts.contest.conclusion_timestamp;
+    if current_conclusion != 0 {
+        require!(now < current_conclusion, VaultError::ContestConcluded);
+    }
+
+    // Timestamp validity (audit #5): non-negative; and if set, must be in the
+    // FUTURE and follow a set lock. The future check matters even on a 1-of-3
+    // first set: a past conclusion would immediately conclude the contest —
+    // enabling settle (the #6 gate) and bricking set_contest_lock_time
+    // (ContestConcluded) — a single-key bypass of the finality guarantee.
+    require!(new_conclusion_timestamp >= 0, VaultError::InvalidTimestamp);
+    if new_conclusion_timestamp != 0 {
+        require!(new_conclusion_timestamp > now, VaultError::InvalidTimestamp);
+        let lock = ctx.accounts.contest.lock_timestamp;
+        if lock != 0 {
+            require!(new_conclusion_timestamp > lock, VaultError::InvalidTimestamp);
+        }
+    }
+
+    // Audit #5: amending an already-set conclusion (clear/postpone) requires
+    // 2-of-3 so a single key can't defeat the "lock is final once concluded"
+    // guarantee. Setting it the first time (0 -> value) stays 1-of-3.
+    if current_conclusion != 0 {
+        let vault_state = ctx.accounts.vault_state.load()?;
+        let cosigner = ctx
+            .accounts
+            .cosigner
+            .as_ref()
+            .ok_or(VaultError::Unauthorized)?;
         require!(
-            Clock::get()?.unix_timestamp < contest.conclusion_timestamp,
-            VaultError::ContestConcluded
+            vault_state.validate_multisig(&ctx.accounts.admin.key(), &cosigner.key()),
+            VaultError::Unauthorized
         );
     }
-    contest.conclusion_timestamp = new_conclusion_timestamp;
+
+    ctx.accounts.contest.conclusion_timestamp = new_conclusion_timestamp;
     msg!(
-        "Contest conclusion_timestamp set to {} for contest_id={:?}",
+        "Contest conclusion_timestamp set to {} for contest_id={:?} (2-of-3 amend: {})",
         new_conclusion_timestamp,
-        contest.contest_id
+        ctx.accounts.contest.contest_id,
+        current_conclusion != 0
     );
     Ok(())
 }

--- a/programs/turf_vault/src/instructions/set_contest_lock_time.rs
+++ b/programs/turf_vault/src/instructions/set_contest_lock_time.rs
@@ -6,19 +6,28 @@ use crate::errors::VaultError;
 ///
 /// Locking is a derived property (v0.17): `enter_contest{,_with_token}` reject
 /// entries once `Clock.unix_timestamp >= contest.lock_timestamp`. This is the
-/// ONLY lock mechanism — there is no separate manual lock/unlock instruction.
-/// "Lock now" is expressed by passing the current chain time;
-/// `new_lock_timestamp == 0` clears the lock (enterable indefinitely).
+/// ONLY lock mechanism. "Lock now" is expressed by passing the current chain
+/// time; `new_lock_timestamp == 0` clears the lock (enterable indefinitely).
 ///
-/// Auth: 1-of-3 vault signer. Adjusting the schedule is a routine op. The value
-/// is unrestricted (may move earlier or later) EXCEPT once the contest has
-/// concluded — there is no point re-opening a graded/cancelled contest.
+/// Auth (v0.19, audit #5):
+///   - BEFORE the lock has passed: 1-of-3 vault signer (routine reschedule).
+///   - AFTER the lock has passed (lock_timestamp != 0 && now >= it): amending
+///     it re-opens a contest whose entry window already closed — the
+///     results-known late-entry vector — so it requires 2-of-3 (admin + a
+///     distinct `cosigner`). Pass `cosigner` only for that case.
+///   - Always rejected once the contest is settled/cancelled or has concluded.
+///
+/// Timestamps must be non-negative; a set lock must precede a set conclusion.
 ///
 /// VaultState is zero-copy (v0.16) — read via `load()?`.
 #[derive(Accounts)]
 pub struct SetContestLockTime<'info> {
     #[account(mut)]
     pub admin: Signer<'info>,
+
+    /// Optional second vault signer. Required (2-of-3) ONLY to amend a lock
+    /// that has already passed; omitted for a routine pre-lock set (1-of-3).
+    pub cosigner: Option<Signer<'info>>,
 
     #[account(
         seeds = [b"vault"],
@@ -39,26 +48,49 @@ pub fn handle_set_contest_lock_time(
     ctx: Context<SetContestLockTime>,
     new_lock_timestamp: i64,
 ) -> Result<()> {
-    let contest = &mut ctx.accounts.contest;
-    // The lock time is final once the contest is settled/cancelled OR has
-    // concluded (its conclusion_timestamp has passed) — see
-    // set_contest_conclusion_time (v0.18).
+    let now = Clock::get()?.unix_timestamp;
+
+    // Final once settled/cancelled or concluded.
     require!(
-        contest.status != ContestStatus::Settled
-            && contest.status != ContestStatus::Cancelled,
+        ctx.accounts.contest.status != ContestStatus::Settled
+            && ctx.accounts.contest.status != ContestStatus::Cancelled,
         VaultError::ContestAlreadySettled
     );
-    if contest.conclusion_timestamp != 0 {
+    let conclusion = ctx.accounts.contest.conclusion_timestamp;
+    if conclusion != 0 {
+        require!(now < conclusion, VaultError::ContestConcluded);
+    }
+
+    // Timestamp validity (audit #5): non-negative; a set lock must precede a
+    // set conclusion. (A past/now value is allowed — it locks immediately.)
+    require!(new_lock_timestamp >= 0, VaultError::InvalidTimestamp);
+    if new_lock_timestamp != 0 && conclusion != 0 {
+        require!(new_lock_timestamp < conclusion, VaultError::InvalidTimestamp);
+    }
+
+    // Audit #5 (re-open protection): once the lock has PASSED, amending it
+    // re-opens a closed entry window — require 2-of-3 (admin + distinct cosigner).
+    let current_lock = ctx.accounts.contest.lock_timestamp;
+    let lock_engaged = current_lock != 0 && now >= current_lock;
+    if lock_engaged {
+        let vault_state = ctx.accounts.vault_state.load()?;
+        let cosigner = ctx
+            .accounts
+            .cosigner
+            .as_ref()
+            .ok_or(VaultError::Unauthorized)?;
         require!(
-            Clock::get()?.unix_timestamp < contest.conclusion_timestamp,
-            VaultError::ContestConcluded
+            vault_state.validate_multisig(&ctx.accounts.admin.key(), &cosigner.key()),
+            VaultError::Unauthorized
         );
     }
-    contest.lock_timestamp = new_lock_timestamp;
+
+    ctx.accounts.contest.lock_timestamp = new_lock_timestamp;
     msg!(
-        "Contest lock_timestamp set to {} for contest_id={:?}",
+        "Contest lock_timestamp set to {} for contest_id={:?} (post-lock 2-of-3 amend: {})",
         new_lock_timestamp,
-        contest.contest_id
+        ctx.accounts.contest.contest_id,
+        lock_engaged
     );
     Ok(())
 }

--- a/programs/turf_vault/src/instructions/settle_contest.rs
+++ b/programs/turf_vault/src/instructions/settle_contest.rs
@@ -1,5 +1,6 @@
 use anchor_lang::prelude::*;
 use anchor_spl::token::{self, Mint, Token, TokenAccount, Transfer};
+use anchor_spl::associated_token::get_associated_token_address;
 use crate::state::{VaultState, UserAccount, Contest, ContestEntry, ContestStatus, EntryStatus};
 use crate::errors::VaultError;
 
@@ -93,6 +94,17 @@ pub fn handle_settle_contest<'info>(
 ) -> Result<()> {
     let contest = &mut ctx.accounts.contest;
 
+    // Audit #6: grading requires a provably-closed entry window. Settle only
+    // once the derived lock OR conclusion timestamp has passed — otherwise a
+    // contest could be graded while still open for entries. Reuses the
+    // existing (dead-but-mapped) ContestNotLocked code. The status==Open||Locked
+    // constraint above still guards against double-settle.
+    let now = Clock::get()?.unix_timestamp;
+    let lock_passed = contest.lock_timestamp != 0 && now >= contest.lock_timestamp;
+    let conclusion_passed =
+        contest.conclusion_timestamp != 0 && now >= contest.conclusion_timestamp;
+    require!(lock_passed || conclusion_passed, VaultError::ContestNotLocked);
+
     // Validate total payouts ≤ prize_pool (entry fees no longer count).
     let total_payouts: u64 = settlements
         .iter()
@@ -125,6 +137,12 @@ pub fn handle_settle_contest<'info>(
     let vault_seeds: &[&[u8]] = &[b"vault", core::slice::from_ref(&vault_bump)];
     let signer_seeds = &[vault_seeds];
 
+    // Audit #3: the pinned payout mint (USDC, == vault_state.payout_mint per the
+    // account constraint). Each winner_ata is bound to the canonical ATA of
+    // (settlement.wallet, payout_mint) below — without this the prize pool can
+    // be redirected to any same-mint account while stats credit the real winner.
+    let payout_mint_key = ctx.accounts.payout_mint.key();
+
     for (i, settlement) in settlements.iter().enumerate() {
         let user_account_info = &remaining[i * 3];
         let entry_account_info = &remaining[i * 3 + 1];
@@ -153,6 +171,17 @@ pub fn handle_settle_contest<'info>(
         require!(
             entry_account_info.key() == expected_entry_pda,
             VaultError::Unauthorized
+        );
+
+        // Audit #3: bind the payout destination to the winner's canonical USDC
+        // ATA. Validated for every row (even zero-payout) so a junk winner_ata
+        // can never be smuggled in. Matches the Rails honest path, which already
+        // derives get_associated_token_address(settlement.wallet, USDC).
+        let expected_winner_ata =
+            get_associated_token_address(&settlement.wallet, &payout_mint_key);
+        require!(
+            winner_ata_info.key() == expected_winner_ata,
+            VaultError::InvalidPayoutDestination
         );
 
         // SPL transfer (PDA-signed): prize_pool → winner_usdc_ata.

--- a/programs/turf_vault/src/lib.rs
+++ b/programs/turf_vault/src/lib.rs
@@ -224,13 +224,15 @@ pub mod turf_vault {
     // ── Free entries ──────────────────────────────────────────────────────
 
     /// Mint a new EntryTokenAccount for a user. 1-of-3 vault signer.
+    /// PDA is derived from sha256(source_ref) (v0.19, audit #9) — re-minting the
+    /// same source_ref collides on init for true on-chain idempotency.
     pub fn mint_entry_token(
         ctx: Context<MintEntryToken>,
-        sequence: u64,
         source: u8,
         source_ref: [u8; 64],
+        source_ref_hash: [u8; 32],
     ) -> Result<()> {
-        handle_mint_entry_token(ctx, sequence, source, source_ref)
+        handle_mint_entry_token(ctx, source, source_ref, source_ref_hash)
     }
 
     // ── Treasury ──────────────────────────────────────────────────────────

--- a/programs/turf_vault/src/state.rs
+++ b/programs/turf_vault/src/state.rs
@@ -299,8 +299,11 @@ pub mod entry_token_source {
 /// EntryTokenAccount: a pre-purchased contest entry token issued by the admin.
 /// User redeems one of these to enter a contest without paying the entry fee at entry time.
 ///
-/// PDA seeds: [b"entry_token", owner.as_ref(), sequence.to_le_bytes().as_ref()]
-/// Discovery: getProgramAccounts filter by `owner`.
+/// PDA seeds (v0.19, audit #9): [b"entry_token", sha256(source_ref)]. Derived
+/// from the external reference's hash so re-minting the same `source_ref`
+/// collides on init (true idempotency); replaces the old caller-supplied
+/// `sequence`. `source_ref` must be globally unique across wallets.
+/// Discovery: getProgramAccounts filter by `owner` (still in the account body).
 #[account]
 pub struct EntryTokenAccount {
     pub owner: Pubkey,            // user wallet


### PR DESCRIPTION
Security hardening from the **2026-05-31 adversarial (Lazarus-persona) audit**. Closes on-chain highs #3, #5, #6, #9. Companion: `docs/SECURITY_AUDIT_2026_05_31.md`.

## Fixes
- **#3 `settle_contest` — bind payout destination.** Each winner's payout must land in `get_associated_token_address(settlement.wallet, payout_mint)`, validated for **every** settlement row before the SPL transfer. Previously the destination ATA was unconstrained → a settle authority (or a tampered/blind-signed 2-of-3 TX) could redirect the prize pool to any same-mint account while stats credited the real winner. New `6036 InvalidPayoutDestination`. Matches the Rails honest path 1:1 (it already derives the canonical ATA).
- **#6 `settle_contest` — entries-closed gate.** Settle now requires the derived lock **or** conclusion timestamp to have passed (reuses `6028 ContestNotLocked`) — a contest can't be graded while still open for entries.
- **#5 `set_contest_lock_time` / `set_contest_conclusion_time` — finality + multisig.** Pre-lock changes stay 1-of-3; **amending a lock that has already passed requires 2-of-3** (optional `cosigner` + `validate_multisig`), closing the results-known late-entry re-open vector. A set conclusion is 2-of-3 to amend (first set stays 1-of-3). Timestamps must be non-negative, a set conclusion must be **in the future**, and a set lock must precede a set conclusion. New `6037 InvalidTimestamp`.
- **#9 `mint_entry_token` — on-chain idempotency.** EntryTokenAccount PDA is seeded on `sha256(source_ref)` (passed as `source_ref_hash`, asserted on-chain) instead of caller-supplied `sequence` → re-minting the same `source_ref` collides on `init`. Kept 1-of-3 (per operator decision — keeps automated Stripe minting working). New `6038 EntryTokenSeedMismatch`.

## Verification
- `cargo check` ✅ and `anchor build` ✅ (BPF `.so` + IDL regenerate cleanly).
- Adversarially reviewed (Jasper). Two code must-fixes folded in: (5a) `set_contest_conclusion_time` now rejects a past/now conclusion — a lone 1-of-3 could otherwise set a past conclusion to force-enable settle and brick the lock; (9b) corrected the stale `state.rs` seed doc.
- ⚠️ The Rust test suite (`tests/turf_vault.ts`) is stale (v0.15.1) and does **not** run against this surface — verify on **devnet** post-deploy (see checklist).

## Account layout: UNCHANGED
No struct in `state.rs` changed → existing PDAs need **no re-init**. The `mint_entry_token` reseed changes future token *addresses*, not the account body; previously-minted tokens stay valid and discoverable by `owner`.

## Deploy runbook (operator — Squads 2-of-3; `anchor deploy` is dead)
1. `anchor build` → `anchor idl build` (capture `target/idl/turf_vault.json` — the BUILT IDL).
2. `solana program write-buffer target/deploy/turf_vault.so --url devnet` → BUFFER_ADDR.
3. `solana program set-buffer-authority <BUFFER_ADDR> --new-buffer-authority BW13kgfiG2koFn3WRkte21NW9TFygsD1ge2fNJdjH6kC --url devnet`.
4. `node scripts/squad-upgrade.js <BUFFER_ADDR>` (propose → approve ×2 → execute).
5. **Re-pin** (OPSEC-014, non-optional — IDL changed): `cp target/idl/turf_vault.json ../turf-monster/config/turf_vault.idl.json`; `shasum -a 256` → new `EXPECTED_IDL_HASH` (replaces `2d87b09…`). Use the BUILT IDL, **not** `anchor idl fetch` (Squad upgrades don't update the on-chain IDL). For reference this branch built to `99d5510…992c8`, but re-build at deploy.
6. `heroku config:set EXPECTED_IDL_HASH=<hash> -a turf-monster` **before** the Rails push; restart Sidekiq (confirm one PID).
7. Tag: `git tag -a v0.19.0 && git push origin main --tags`.

## Rails coordination (separate turf-monster PR — deploys AFTER the upgrade)
- `vault.rb` `entry_token_pda` → derive from `sha256(source_ref)`; `mint_entry_token` passes `source_ref_hash`, drops `sequence`; delete `next_entry_token_sequence`. **Add a Ruby==program PDA unit test** (hash-input mismatch is the #1 footgun — same 64-byte zero-padded buffer).
- **Regression to fix:** `admin/free_entries_controller.rb` mints N tokens with `source_ref "operator_<unix_ts>"` in a loop → under the new seed all N collide in one second (mints 1 of N). Make it per-mint globally unique.
- `grade!` must ensure a lock/conclusion is set before settle (else on-chain `6028` revert); cosign path for post-lock lock/conclusion amends; `error_interpreter` mappings for 6036/6037/6038.
- **Backfill:** any open contest with `lock_timestamp == 0 && conclusion_timestamp == 0` becomes un-settleable under #6 — set a lock (or cancel) before grading.

🤖 Generated with [Claude Code](https://claude.com/claude-code)